### PR TITLE
Remove dependencies of dependencies from requirements.txt

### DIFF
--- a/dj-script
+++ b/dj-script
@@ -1,4 +1,12 @@
 #!/bin/bash
+
+pip-install-and-add-to-requirements () {
+    pkg=$(echo $1 | tr "[:upper:]" "[:lower:]")
+    pip install $pkg
+    versioned=$(pip freeze | tr "[:upper:]" "[:lower:]" | grep $pkg==)
+    echo $versioned >> requirements.txt
+}
+
 if [ -z $1 ] 
 then
     echo "passe o nome do projeto como parametro, tipo: ./dj-script projeto"
@@ -10,13 +18,14 @@ else
 	python -m venv .$1
 	source .$1/bin/activate 
 	
-	#atualiza o pip e instala as libs
+	#atualiza o pip, instala as libs e cria o requirements.txt
+	touch requirements.txt
 	pip install --upgrade pip
-	pip install django
-	pip install python-decouple
-	pip install dj-database-url
-	pip install dj-static
-	pip install django-test-without-migrations
+	pip-install-and-add-to-requirements django
+	pip-install-and-add-to-requirements python-decouple
+	pip-install-and-add-to-requirements dj-database-url
+	pip-install-and-add-to-requirements dj-static
+	pip-install-and-add-to-requirements django-test-without-migrations
 
 	#cria o projeto django e a app core
 	django-admin startproject $1 .
@@ -28,9 +37,6 @@ else
 	echo -e ".$1\n.env\n.idea\n*.sqlite3\n*pyc\n__pycache__\nstaticfiles" > .gitignore
 	
 	#prepara a configuração para o Heroku
-	pip freeze > requirements.txt
 	echo -e "gunicorn==19.9.0\npsycopg2==2.8.3" >> requirements.txt
 	echo "web: gunicorn $1.wsgi --log-file - :" > Procfile
 fi
-
-


### PR DESCRIPTION
The `pip freeze > requirements.txt` approach unnecessarily inflates `requirements.txt` including dependencies of dependencies in that file (in this case: `pytz`, `sqlparse` and `static3`).

This commit creates a function `pip-install-and-add-to-requirements` to better handle this case. Line by line, this is the logic:

1. creates a variable `pkg` with the name of the package standardized to lowercase (it's useful because `pip install django`, for example, results in `Django==…` in `pip freeze`)
2. installs the package
3. gets the line of the installed package from `pip freeze` (pipes the result of `pip freeze` to a command that converts it to lowercase, than search with `grep` for an occurrence of `pkg` followed by the string `==`)
4. writes the string of the line above to the bottom of `requirements.txt`